### PR TITLE
Replace uses of deprecated alias 'np.int' by builtin 'int'

### DIFF
--- a/scalesim/compute/operand_matrix.py
+++ b/scalesim/compute/operand_matrix.py
@@ -30,9 +30,9 @@ class operand_matrix(object):
         self.matrix_offset_arr = [0, 10000000, 20000000]
 
         # Address matrices
-        self.ifmap_addr_matrix = np.ones((self.ofmap_px_per_filt, self.conv_window_size), dtype=np.int)
-        self.filter_addr_matrix = np.ones((self.conv_window_size, self.num_filters), dtype=np.int)
-        self.ofmap_addr_matrix = np.ones((self.ofmap_px_per_filt, self.num_filters), dtype=np.int)
+        self.ifmap_addr_matrix = np.ones((self.ofmap_px_per_filt, self.conv_window_size), dtype=int)
+        self.filter_addr_matrix = np.ones((self.conv_window_size, self.num_filters), dtype=int)
+        self.ofmap_addr_matrix = np.ones((self.ofmap_px_per_filt, self.num_filters), dtype=int)
 
         # Flags
         self.params_set_flag = False

--- a/scalesim/memory/double_buffered_scratchpad_mem.py
+++ b/scalesim/memory/double_buffered_scratchpad_mem.py
@@ -21,9 +21,9 @@ class double_buffered_scratchpad:
 
         self.verbose = True
 
-        self.ifmap_trace_matrix = np.zeros((1,1), dtype=np.int)
-        self.filter_trace_matrix = np.zeros((1,1), dtype=np.int)
-        self.ofmap_trace_matrix = np.zeros((1,1), dtype=np.int)
+        self.ifmap_trace_matrix = np.zeros((1,1), dtype=int)
+        self.filter_trace_matrix = np.zeros((1,1), dtype=int)
+        self.ofmap_trace_matrix = np.zeros((1,1), dtype=int)
 
         # Metrics to gather for generating run reports
         self.total_cycles = 0


### PR DESCRIPTION
Fixes #66 