### PR TITLE
Replacement of os.system calls with os.mkdir. (Fixes Issue #68)

### DIFF
--- a/scalesim/simulator.py
+++ b/scalesim/simulator.py
@@ -57,14 +57,12 @@ class simulator:
             self.single_layer_sim_object_list.append(this_layer_sim)
 
         if not os.path.isdir(self.top_path):
-            cmd = 'mkdir ' + self.top_path
-            os.system(cmd)
+            os.mkdir(self.top_path)
 
         report_path = self.top_path + '/' + self.conf.get_run_name()
 
         if not os.path.isdir(report_path):
-            cmd = 'mkdir ' + report_path
-            os.system(cmd)
+            os.mkdir(report_path)
 
         self.top_path = report_path
 

--- a/scalesim/single_layer_sim.py
+++ b/scalesim/single_layer_sim.py
@@ -187,8 +187,7 @@ class single_layer_sim:
 
         dir_name = top_path + '/layer' + str(self.layer_id)
         if not os.path.isdir(dir_name):
-            cmd = 'mkdir ' + dir_name
-            os.system(cmd)
+            os.mkdir(dir_name)
 
         ifmap_sram_filename = dir_name +  '/IFMAP_SRAM_TRACE.csv'
         filter_sram_filename = dir_name + '/FILTER_SRAM_TRACE.csv'


### PR DESCRIPTION
Hi,
This pull request replaces all calls to os.system() with os.mkdir() when trying to create directories. I don't think any modifications to documentation are needed since it doesn't change the public interface.

The program no longer crashes on Windows, addresses #68. The problems were caused by the Windows command line not accepting forward slashes. I verified that the test script runs correctly on Ubuntu and Windows. The function_test.sh test runs correctly on Ubuntu (can't run on windows due to not having bash).

An alternative is replacing all path string manipulations with pathlib. It might be better coding practice that way but the modifications ballooned in scope very quickly. I am not sure if it would break other parts of the project since the 2 tests in GitHub actions don't seem to cover every part of the project.  The WIP modifications for switching to pathlib can be found [here](https://github.com/semicolonTransistor/scale-sim-v2/tree/switch-to-pathlib). 

Thanks
