### PR TITLE
Fix NumPy array to scalar conversion due to deprecation

### DIFF
--- a/scalesim/memory/double_buffered_scratchpad_mem.py
+++ b/scalesim/memory/double_buffered_scratchpad_mem.py
@@ -304,7 +304,7 @@ class double_buffered_scratchpad:
                                                  axis=1)
         #self.total_cycles = int(ofmap_serviced_cycles[-1][0])
         ## Probable fault in sanity check
-        self.total_cycles = int(max(ofmap_serviced_cycles))
+        self.total_cycles = int(np.max(ofmap_serviced_cycles))
 
         # END of serving demands from memory
         self.traces_valid = True


### PR DESCRIPTION
## Issue

`double_buffered_scratchpad_mem.py` computes `total_cycles` using `int(max(ofmap_serviced_cycles))`.

`ofmap_serviced_cycles` contains NumPy arrays, so `max(...)` can return a one-dimensional NumPy array. NumPy 1.25 deprecated converting arrays with `ndim > 0` directly to scalars, and newer NumPy versions raise a `TypeError`.

## Fixes

This uses `np.max(ofmap_serviced_cycles)` before converting to `int`.

Resolves failures like: `TypeError: only 0-dimensional arrays can be converted to Python scalars`

## Resources
> Only ndim-0 arrays are treated as scalars.

[NumPy 1.25 Release Notes](https://numpy.net/doc/stable/release/1.25.0-notes.html#deprecations#:~:text=Only%20ndim)

Starting with NumPy 2.4.0 ([Released in **Dec 2025**](https://numpy.org/news/#numpy-240-released)), this expired deprecation now raises a `TypeError`.
> Raise TypeError on attempt to convert array with ndim > 0 to scalar

[NumPy 2.4.0](https://numpy.org/doc/stable/release/2.4.0-notes.html#raise-typeerror-on-attempt-to-convert-array-with-ndim-0-to-scalar)

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a4dd3947-92bb-4c19-9379-d35b1fc0e672" />
