### PR TITLE
Fix directory creation on Windows

### DIFF
--- a/scalesim/single_layer_sim.py
+++ b/scalesim/single_layer_sim.py
@@ -304,9 +304,7 @@ class single_layer_sim:
         assert self.params_set_flag, 'Parameters are not set'
 
         dir_name = top_path + '/layer' + str(self.layer_id)
-        if not os.path.isdir(dir_name):
-            cmd = 'mkdir ' + dir_name
-            os.system(cmd)
+        os.makedirs(dir_name, exist_ok=True)
 
         ifmap_sram_filename = dir_name +  '/IFMAP_SRAM_TRACE.csv'
         filter_sram_filename = dir_name + '/FILTER_SRAM_TRACE.csv'


### PR DESCRIPTION
## Issue

`single_layer_sim.py` creates layer directories using a shell `mkdir` command built from the output path.

On Windows, this can fail when the path contains spaces, such as `My Path`, resulting in the message `The syntax of the command is incorrect`.

## Fixes

This replaces the shell-based `mkdir` call with `os.makedirs(..., exist_ok=True)`.

This also removes the separate `os.path.isdir` check because `os.makedirs(..., exist_ok=True)` already handles both cases:
- creates the directory if it does not exist
- does nothing if the directory already exists

## Resources
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e4335af2-d9ca-4b7b-a9a8-5eaf6725be06" />